### PR TITLE
fix cgroup2 mnt point issue on focal

### DIFF
--- a/vmtop.py
+++ b/vmtop.py
@@ -819,7 +819,7 @@ class Machine:
 
             # Avoid scenrio where m is empty
             if m:
-                if m[0] == 'cgroup':
+                if m[0] == 'cgroup' or m[0] == 'cgroup2':
                     if 'unified' in m[1]:
                         continue
                     if 'cpuset' in m[3]:


### PR DESCRIPTION
vmtop was failing to run in cgroup2 focal based env
returning following error:

AttributeError: 'Machine' object has no attribute 'cpuset_mount_point'

Between bionic vs focal, cgroup2 when configured in unified mode,
mount point name is changed from cgroup to cgroup2 causing focal
based env with cgroup2 to not run.

This fixes it.