### PR TITLE
Remove LXD-specific assumption

### DIFF
--- a/vmtop.py
+++ b/vmtop.py
@@ -467,9 +467,6 @@ class VM:
     def is_vcpu(self, thread, comm):
         if 'CPU' in comm:
             return True
-        # hack for LXD-managed VMs
-        if len(thread.nodes) == 1:
-            return True
 
     def get_threads(self):
         for tid in os.listdir('/proc/%s/task/' % self.vm_pid):


### PR DESCRIPTION
With LXD only the vcpu threads are pinned to a node, but this is not
enough to mark a thread as a VCPU for other cases. We need a better
solution here.

Signed-off-by: Julien Desfossez <jdesfossez@digitalocean.com>