### PR TITLE
Fix refresh rate

### DIFF
--- a/vmtop.py
+++ b/vmtop.py
@@ -1272,8 +1272,13 @@ class VmTop:
                     self.emulators_steal_gauge.labels(node=node.id).set(node.node_emulators_sum_pc_util)
                     self.emulators_steal_gauge.labels(node=node.id).set(node.node_emulators_sum_pc_steal)
 
+        self.wait_refresh()
 
-        time.sleep(self.args.refresh)
+    def wait_refresh(self):
+        for i in range(self.args.refresh * 2):
+            if stop is True:
+                return
+            time.sleep(0.5)
 
     def loop(self):
         while stop == False:
@@ -1462,6 +1467,7 @@ def main():
                 start_prometheus_client(ip, port)
 
             s = VmTop(args)
+            s.wait_refresh()
             if args.number > 0:
                 s.run(args.number)
             else:
@@ -1469,6 +1475,7 @@ def main():
 
     else:
         s = VmTop(args)
+        s.wait_refresh()
 
         if args.number > 0:
             s.run(args.number)


### PR DESCRIPTION
There were 2 bugs:
- immediately after starting vmtop, we would output metrics without waiting the refresh period. It wasn't a big issue with the default refresh rate of 1s, but for anything longer it was misleading to output 1 report immediately and then wait the appropriate duration.
- if the user wanted to exit with ctrl-c, we were waiting for a full refresh period to actually exit. Again, barely noticeable with a refresh of 1s, but anything longer was annoying.

This commit fixes both issues by making the tool wait for a full refresh period before its first output, and by checking the "stop" flag while waiting for the next refresh output.

Signed-off-by: Julien Desfossez <jdesfossez@digitalocean.com>